### PR TITLE
make map state pushState agnostic of base url

### DIFF
--- a/docs/static/js/map_creation.js
+++ b/docs/static/js/map_creation.js
@@ -19,7 +19,7 @@ function UIState(){
     url.searchParams.set('lat', Math.round(this.lat * 100000) / 100000);
     url.searchParams.set('z', Math.round(this.zoom * 100) / 100);
     url.searchParams.set('div',map_state.division);
-    window.history.pushState('page2', 'Title', '/phila_political/'+url.search);
+    window.history.pushState('page2', 'Title', url.search);
   }
 }
 


### PR DESCRIPTION
Removed hard-coded `phila_political` base url used in the update_url function. This should make the map save-state functionality work regardless of whatever the base url is.