### PR TITLE
update config file to reference new electeds

### DIFF
--- a/docs/static/js/config.js
+++ b/docs/static/js/config.js
@@ -28,7 +28,7 @@ sources = [
     "name": "Phila City Council",
     "data":{
       "type": "geojson",
-      "data": "https://raw.githubusercontent.com/aerispaha/reclaim_map/dev/data/spatial/20190401/philly-council-officials.geojson"
+      "data": "https://raw.githubusercontent.com/reclaimphiladelphia/reclaim_map/master/data/spatial/20210912/philly-council-officials.geojson"
     }
   },
   {
@@ -36,7 +36,7 @@ sources = [
     "name":"PA Legislative",
     "data":{
       "type": "geojson",
-      "data": "https://raw.githubusercontent.com/aerispaha/reclaim_map/dev/data/spatial/20190401/pa-legis-officials-2019.geojson"
+      "data": "https://raw.githubusercontent.com/reclaimphiladelphia/reclaim_map/master/data/spatial/20210912/pa-legis-officials.geojson"
     }
   },
   {
@@ -44,7 +44,7 @@ sources = [
     "name":"PA Senate",
     "data":{
       "type": "geojson",
-      "data": "https://raw.githubusercontent.com/aerispaha/reclaim_map/dev/data/spatial/20190401/pa-senate-officials-2019.geojson"
+      "data": "https://raw.githubusercontent.com/reclaimphiladelphia/reclaim_map/master/data/spatial/20210912/pa-senate-officials.geojson"
     }
   },
   {

--- a/docs/static/js/functions.js
+++ b/docs/static/js/functions.js
@@ -8,7 +8,7 @@ function UIState(){
   this.lat = url.searchParams.get('lat') || 39.94848811327782;
   this.zoom = url.searchParams.get('z') || 13;
   this.filterVal = Number(url.searchParams.get('fval') || NaN);
-  this.activeLayer = url.searchParams.get('lyr') || 'phila-wards';
+  this.activeLayer = url.searchParams.get('lyr') || 'divisions';
 
   // that = this;
   this.update_url = function(){

--- a/scripts/join_committeepeople_to_divisions.py
+++ b/scripts/join_committeepeople_to_divisions.py
@@ -53,12 +53,11 @@ def join_committeepeople_to_divisions(cp_pth=None, div_pth=None, out_pth=None):
         ward =  int(properties['DIVISION_NUM'][:2])
         div = int(properties['DIVISION_NUM'][2:])
 
-        print (properties)
         try:
             #look up in dataframe
-            peep_data = df.ix[ward, div]
+            peep_data = df.loc[ward, div]
             peep_list = peep_data.to_json(orient='records')
-
+            # print(properties)
             #update the geojson properties
             properties.update({'committeepeople':json.loads(peep_list)})
 


### PR DESCRIPTION
This references new spatial datasets hosted on Github with updates to City Council, State Senate, and State Legislator elected officials. Additionally, this make Ward Divisions the default layer shown in the map. 


Closes #47 
Closes #46 
Closes #45 
Closes #43 