### PR TITLE
point config to updated datasets for ward leaders and committee people

### DIFF
--- a/docs/static/js/config.js
+++ b/docs/static/js/config.js
@@ -4,7 +4,7 @@ sources = [
     "name":"Divisions",
     "data":{
       "type": "geojson",
-      "data": "https://raw.githubusercontent.com/aerispaha/reclaim_map/dev/data/spatial/20190401/divisions-officials.geojson"
+      "data": "https://raw.githubusercontent.com/reclaimphiladelphia/reclaim_map/master/data/spatial/20220926/divisions-officials.geojson"
     },
   },
   {
@@ -12,7 +12,7 @@ sources = [
     "name":"Philly Wards",
     "data":{
       "type": "geojson",
-      "data": "https://raw.githubusercontent.com/aerispaha/reclaim_map/dev/data/spatial/20190401/wards-officials.geojson"
+      "data": "https://raw.githubusercontent.com/reclaimphiladelphia/reclaim_map/master/data/spatial/20220926/wards-officials.geojson"
     }
   },
   {


### PR DESCRIPTION
### Summary
After updating committee people and ward leader data and generating new geojson datasets in 8e5e1f753 and 2d97e888e9, this changes what data files are referenced in the production map for the Divisions and Wards layers.

#### Notes
- Updated committee people are included in the attached CSV file: [phl-dem-cp-2022.csv](https://github.com/reclaimphiladelphia/reclaim_map/files/9649757/phl-dem-cp-2022.csv) 
- Ward leader updates were based data found [here](https://www.phillywardleaders.com/leaders/democratic). 
- 131 divisions were not updated as no entry was found in the phl-dem-cp-2022.csv spreadsheet. These unchanged seats are included in [divisions-not-updated.csv](https://github.com/reclaimphiladelphia/reclaim_map/files/9649764/divisions-not-updated.csv) for reference. 



